### PR TITLE
Screen Sharing UI

### DIFF
--- a/components/screens/ActiveVideoRoom/FocusedTrackView/FocusedTrackView.tsx
+++ b/components/screens/ActiveVideoRoom/FocusedTrackView/FocusedTrackView.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import * as Video from "twilio-video";
+import { Box, Flex } from "@twilio-paste/core";
+
+import Participant from "../Participant/Participant";
+import ParticipantList from "../ParticipantList/ParticipantList";
+import { FocusedTrackViewContainer } from "../../../styled";
+
+interface OrderedParticipant {
+  participant: Video.RemoteParticipant;
+  dominantSpeakerStartTime: number;
+}
+
+interface FocusedTrackViewProps {
+  orderedParticipants: OrderedParticipant[];
+  dominantSpeaker: Video.RemoteParticipant | null;
+  screenShareParticipant: any;
+}
+
+export default function FocusedTrackView({
+  orderedParticipants,
+  dominantSpeaker,
+  screenShareParticipant,
+}: FocusedTrackViewProps) {
+  return (
+    <FocusedTrackViewContainer>
+      <Flex width={["100%"]} height="100%" vertical={[true, true, false]}>
+        {/* Main Track Container */}
+        <Box
+          width={["100%", "100%", "80%"]}
+          height={["80%", "80%", "100%"]}
+          verticalAlign="center"
+        >
+          <Flex width={"100%"} height="100%" vAlignContent={"center"}>
+            <Participant
+              participant={screenShareParticipant}
+              isLocalParticipant={false}
+              isMainFocus
+            />
+          </Flex>
+        </Box>
+        {/* Participant List Container */}
+        <Box width={["100%", "100%", "20%"]} height={["20%", "20%", "100%"]}>
+          <ParticipantList
+            orderedParticipants={orderedParticipants}
+            screenShareParticipant={screenShareParticipant}
+            dominantSpeaker={dominantSpeaker}
+          />
+        </Box>
+      </Flex>
+    </FocusedTrackViewContainer>
+  );
+}

--- a/components/screens/ActiveVideoRoom/GridView/GridView.tsx
+++ b/components/screens/ActiveVideoRoom/GridView/GridView.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import * as Video from "twilio-video";
+
+import { useVideoStore, VideoAppState } from "../../../../store/store";
+import { GridViewContainer } from "../../../styled";
+import Participant from "../Participant/Participant";
+import {
+  GALLERY_VIEW_ASPECT_RATIO,
+  GALLERY_VIEW_MARGIN,
+} from "../../../../lib/constants";
+import useGalleryViewLayout from "../../../../lib/hooks/useGalleryViewLayout";
+
+interface OrderedParticipant {
+  participant: Video.RemoteParticipant;
+  dominantSpeakerStartTime: number;
+}
+
+interface GridViewProps {
+  orderedParticipants: OrderedParticipant[];
+  dominantSpeaker: Video.RemoteParticipant | null;
+}
+
+export default function GridView({
+  orderedParticipants,
+  dominantSpeaker,
+}: GridViewProps) {
+  const { room } = useVideoStore((state: VideoAppState) => state);
+  const numParticipants =
+    orderedParticipants.length > 0 ? orderedParticipants.length + 1 : 1;
+  const { participantVideoWidth, containerRef } =
+    useGalleryViewLayout(numParticipants);
+  const participantWidth = `${participantVideoWidth}px`;
+  const participantHeight = `${Math.floor(
+    participantVideoWidth * GALLERY_VIEW_ASPECT_RATIO
+  )}px`;
+
+  return (
+    <GridViewContainer ref={containerRef}>
+      {orderedParticipants.length > 0 &&
+        orderedParticipants.map((remoteParticipant: OrderedParticipant) => {
+          const isDominant = !!dominantSpeaker
+            ? dominantSpeaker.sid === remoteParticipant.participant.sid
+            : false;
+          return (
+            <div
+              key={remoteParticipant.participant.sid}
+              style={{
+                width: participantWidth,
+                height: participantHeight,
+                margin: GALLERY_VIEW_MARGIN,
+              }}
+            >
+              <Participant
+                participant={remoteParticipant.participant}
+                isLocalParticipant={false}
+                isDominantSpeaker={isDominant}
+                isMainFocus={false}
+              />
+            </div>
+          );
+        })}
+      <div
+        key={room!.localParticipant.sid}
+        style={{
+          width: participantWidth,
+          height: participantHeight,
+          margin: GALLERY_VIEW_MARGIN,
+        }}
+      >
+        <Participant
+          participant={room!.localParticipant}
+          isLocalParticipant
+          isMainFocus={false}
+        />
+      </div>
+    </GridViewContainer>
+  );
+}

--- a/components/screens/ActiveVideoRoom/LocalControls/ToggleAudio/ToggleAudio.tsx
+++ b/components/screens/ActiveVideoRoom/LocalControls/ToggleAudio/ToggleAudio.tsx
@@ -17,7 +17,7 @@ export default function ToggleAudio() {
     if (audioTrack) {
       audioTrack.isEnabled ? audioTrack.disable() : audioTrack.enable();
     } else {
-      console.log("setup local audio track");
+      // setup local audio track
       navigator.mediaDevices
         .enumerateDevices()
         .then((devices) => {
@@ -30,13 +30,11 @@ export default function ToggleAudio() {
           });
         })
         .then((localTracks) => {
-          console.log("localTracks...", localTracks);
           room?.localParticipant?.publishTrack(localTracks[0]);
           setLocalTracks("audio", localTracks[0]);
           setDevicePermissions("camera", true);
         })
         .catch((error) => {
-          console.log("error", error.message);
           toaster.push({
             message: `Error starting microphone - ${error.message}`,
             variant: "error",

--- a/components/screens/ActiveVideoRoom/LocalControls/ToggleVideo/ToggleVideo.tsx
+++ b/components/screens/ActiveVideoRoom/LocalControls/ToggleVideo/ToggleVideo.tsx
@@ -25,7 +25,7 @@ export default function ToggleVideo() {
         room?.localParticipant?.emit("trackUnpublished", localTrackPublication);
       } else {
         setIsPublishing(true);
-        console.log("setup local video track");
+        // setup local video track
         navigator.mediaDevices
           .enumerateDevices()
           .then((devices) => {
@@ -38,13 +38,11 @@ export default function ToggleVideo() {
             });
           })
           .then((localTracks) => {
-            console.log("localTracks...", localTracks);
             room?.localParticipant?.publishTrack(localTracks[0]);
             setLocalTracks("video", localTracks[0]);
             setIsPublishing(false);
           })
           .catch((error) => {
-            console.log("error", error.message);
             toaster.push({
               message: `Error enabling Camera - ${error.message}`,
               variant: "error",

--- a/components/screens/ActiveVideoRoom/Participant/Participant.tsx
+++ b/components/screens/ActiveVideoRoom/Participant/Participant.tsx
@@ -8,6 +8,8 @@ import {
   LocalAudioTrack,
   LocalVideoTrack,
 } from "twilio-video";
+import { BsMicFill, BsMicMute } from "react-icons/bs";
+import { TbScreenShare } from "react-icons/tb";
 
 import ParticipantTracks from "../ParticipantTracks/ParticipantTracks";
 import usePublications from "../../../../lib/hooks/usePublications";
@@ -21,12 +23,12 @@ import {
   AvatarContainer,
 } from "../../../styled";
 import useIsTrackEnabled from "../../../../lib/hooks/useIsTrackEnabled";
-import { BsMicFill, BsMicMute } from "react-icons/bs";
 
 interface RoomParticipantProps {
   participant: IParticipant;
   isLocalParticipant: boolean;
   isDominantSpeaker?: boolean;
+  isMainFocus: boolean;
 }
 
 /* WORK IN PROGRESS */
@@ -35,6 +37,7 @@ export default function Participant({
   participant,
   isLocalParticipant,
   isDominantSpeaker,
+  isMainFocus,
 }: RoomParticipantProps) {
   const { identity } = participant;
   const publications = usePublications(participant);
@@ -46,6 +49,7 @@ export default function Participant({
   const isScreenShareEnabled = publications.find((p) =>
     p.trackName.includes("screen")
   );
+
   const videoTrack = useTrack(videoPublication);
   const isVideoSwitchedOff = useIsTrackSwitchedOff(
     videoTrack as LocalVideoTrack | RemoteVideoTrack
@@ -65,6 +69,7 @@ export default function Participant({
       }`,
       borderRadius: "10px",
       width: "100%",
+      backgroundColor: "#000000",
     })
   );
 
@@ -73,6 +78,16 @@ export default function Participant({
       <VideoPreviewContainer>
         <OverlayContent>
           <Stack orientation="horizontal" spacing="space10">
+            {!!isScreenShareEnabled && (
+              <TbScreenShare
+                style={{
+                  width: "14px",
+                  height: "14px",
+                  marginTop: "4px",
+                  marginRight: "3px",
+                }}
+              />
+            )}
             {isAudioEnabled ? (
               <BsMicFill
                 style={{
@@ -90,6 +105,7 @@ export default function Participant({
                 }}
               />
             )}
+
             <Text
               as="p"
               color="colorText"
@@ -100,7 +116,7 @@ export default function Participant({
           </Stack>
         </OverlayContent>
         <InnerPreviewContainer>
-          {(!isVideoEnabled || isVideoSwitchedOff) && (
+          {!isMainFocus && (!isVideoEnabled || isVideoSwitchedOff) && (
             <AvatarContainer>
               <Avatar size={["sizeIcon70", "sizeIcon110"]} name={identity} />
             </AvatarContainer>
@@ -108,6 +124,7 @@ export default function Participant({
           <ParticipantTracks
             isLocal={isLocalParticipant}
             participant={participant}
+            isMainFocus={isMainFocus}
           />
         </InnerPreviewContainer>
       </VideoPreviewContainer>

--- a/components/screens/ActiveVideoRoom/ParticipantList/ParticipantList.tsx
+++ b/components/screens/ActiveVideoRoom/ParticipantList/ParticipantList.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import * as Video from "twilio-video";
+
+import { useVideoStore, VideoAppState } from "../../../../store/store";
+import Participant from "../Participant/Participant";
+import {
+  GALLERY_VIEW_ASPECT_RATIO,
+  GALLERY_VIEW_MARGIN,
+} from "../../../../lib/constants";
+import useGalleryViewLayout from "../../../../lib/hooks/useGalleryViewLayout";
+import { ParticipantListContainer } from "../../../styled";
+
+interface OrderedParticipant {
+  participant: Video.RemoteParticipant;
+  dominantSpeakerStartTime: number;
+}
+
+interface GridViewProps {
+  orderedParticipants: OrderedParticipant[];
+  dominantSpeaker: Video.RemoteParticipant | null;
+  screenShareParticipant: any;
+}
+
+export default function ParticipantList({
+  orderedParticipants,
+  dominantSpeaker,
+  screenShareParticipant,
+}: GridViewProps) {
+  const { room } = useVideoStore((state: VideoAppState) => state);
+  const numParticipants =
+    orderedParticipants.length > 0 ? orderedParticipants.length + 1 : 1;
+  const { participantVideoWidth, containerRef } =
+    useGalleryViewLayout(numParticipants);
+  const participantWidth = `${participantVideoWidth}px`;
+  const participantHeight = `${Math.floor(
+    participantVideoWidth * GALLERY_VIEW_ASPECT_RATIO
+  )}px`;
+
+  return (
+    <ParticipantListContainer ref={containerRef}>
+      {orderedParticipants.length > 0 &&
+        orderedParticipants.map((remoteParticipant: OrderedParticipant) => {
+          const isDominant = !!dominantSpeaker
+            ? dominantSpeaker.sid === remoteParticipant.participant.sid
+            : false;
+
+          return (
+            <div
+              key={remoteParticipant.participant.sid}
+              style={{
+                width: participantWidth,
+                height: participantHeight,
+                margin: GALLERY_VIEW_MARGIN,
+              }}
+            >
+              <Participant
+                participant={remoteParticipant.participant}
+                isLocalParticipant={false}
+                isDominantSpeaker={isDominant}
+                isMainFocus={false}
+              />
+            </div>
+          );
+        })}
+      <div
+        key={room!.localParticipant.sid}
+        style={{
+          width: participantWidth,
+          height: participantHeight,
+          margin: GALLERY_VIEW_MARGIN,
+        }}
+      >
+        <Participant
+          participant={room!.localParticipant}
+          isLocalParticipant
+          isMainFocus={false}
+        />
+      </div>
+    </ParticipantListContainer>
+  );
+}

--- a/components/screens/ActiveVideoRoom/ParticipantTracks/ParticipantTracks.tsx
+++ b/components/screens/ActiveVideoRoom/ParticipantTracks/ParticipantTracks.tsx
@@ -7,11 +7,12 @@ import Publication from "../Publication/Publication";
 interface ParticipantTracksProps {
   participant: Participant;
   isLocal: boolean;
+  isMainFocus: boolean;
 }
 
 export default function ParticipantTracks({
   participant,
-  isLocal,
+  isMainFocus,
 }: ParticipantTracksProps) {
   const publications = usePublications(participant);
   let enableScreenShare = true;
@@ -19,12 +20,13 @@ export default function ParticipantTracks({
 
   if (
     enableScreenShare &&
+    isMainFocus &&
     publications.some((p) => p.trackName.includes("screen"))
   ) {
     // When displaying a screenshare track is allowed, and a screen share track exists,
     // remove all video tracks without the name 'screen'.
-    filteredPublications = publications.filter(
-      (p) => p.trackName.includes("screen") || p.kind !== "video"
+    filteredPublications = publications.filter((p) =>
+      p.trackName.includes("screen")
     );
   } else {
     // Else, remove all screenshare tracks

--- a/components/styled.ts
+++ b/components/styled.ts
@@ -71,7 +71,7 @@ export const OverlayContent = styled.div(
   })
 );
 const CONTAINER_GUTTER = "30px";
-export const ParticipantContainer = styled.div(
+export const GridViewContainer = styled.div(
   css({
     height: "calc(100vh - 160px)",
     position: "absolute",
@@ -80,6 +80,34 @@ export const ParticipantContainer = styled.div(
     right: CONTAINER_GUTTER,
     bottom: CONTAINER_GUTTER,
     left: CONTAINER_GUTTER,
+    margin: "0 auto",
+    alignContent: "center",
+    flexWrap: "wrap",
+    justifyContent: "center",
+  })
+);
+
+const FOCUSED_CONTAINER_GUTTER = "15px";
+export const FocusedTrackViewContainer = styled.div(
+  css({
+    height: "calc(100vh - 160px)",
+    position: "absolute",
+    display: "flex",
+    top: FOCUSED_CONTAINER_GUTTER,
+    right: FOCUSED_CONTAINER_GUTTER,
+    bottom: FOCUSED_CONTAINER_GUTTER,
+    left: FOCUSED_CONTAINER_GUTTER,
+    margin: "0 auto",
+    alignContent: "center",
+    flexWrap: "wrap",
+    justifyContent: "center",
+  })
+);
+
+export const ParticipantListContainer = styled.div(
+  css({
+    height: "100%",
+    display: "flex",
     margin: "0 auto",
     alignContent: "center",
     flexWrap: "wrap",

--- a/lib/hooks/useScreenShareParticipant.tsx
+++ b/lib/hooks/useScreenShareParticipant.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+import { Participant, TrackPublication, Room } from "twilio-video";
+
+/*
+  Returns the participant that is sharing their screen (if any). This hook assumes that only one participant
+  can share their screen at a time.
+*/
+export default function useScreenShareParticipant(room: Room | null) {
+  const [screenShareParticipant, setScreenShareParticipant] =
+    useState<Participant>();
+
+  useEffect(() => {
+    if (room) {
+      const updateScreenShareParticipant = () => {
+        setScreenShareParticipant(
+          Array.from<Participant>(room.participants.values())
+            // the screenshare participant could be the localParticipant
+            .concat(room.localParticipant)
+            .find((participant: Participant) =>
+              Array.from<TrackPublication>(participant.tracks.values()).find(
+                (track) => track.trackName.includes("screen")
+              )
+            )
+        );
+      };
+      updateScreenShareParticipant();
+
+      room.on("trackPublished", updateScreenShareParticipant);
+      room.on("trackUnpublished", updateScreenShareParticipant);
+      room.on("participantDisconnected", updateScreenShareParticipant);
+
+      // the room object does not emit 'trackPublished' events for the localParticipant,
+      // so we need to listen for them here.
+      room.localParticipant.on("trackPublished", updateScreenShareParticipant);
+      room.localParticipant.on(
+        "trackUnpublished",
+        updateScreenShareParticipant
+      );
+      return () => {
+        room.off("trackPublished", updateScreenShareParticipant);
+        room.off("trackUnpublished", updateScreenShareParticipant);
+        room.off("participantDisconnected", updateScreenShareParticipant);
+
+        room.localParticipant.off(
+          "trackPublished",
+          updateScreenShareParticipant
+        );
+        room.localParticipant.off(
+          "trackUnpublished",
+          updateScreenShareParticipant
+        );
+      };
+    }
+  }, [room]);
+
+  return screenShareParticipant;
+}

--- a/lib/hooks/useScreenShareToggle.tsx
+++ b/lib/hooks/useScreenShareToggle.tsx
@@ -1,0 +1,68 @@
+import { useState, useCallback, useRef } from "react";
+import { LogLevels, Track, Room } from "twilio-video";
+import { ErrorCallback } from "../types";
+
+interface MediaStreamTrackPublishOptions {
+  name?: string;
+  priority: Track.Priority;
+  logLevel: LogLevels;
+}
+
+export default function useScreenShareToggle(
+  room: Room | null,
+  onError: ErrorCallback
+) {
+  const [isSharing, setIsSharing] = useState(false);
+  const stopScreenShareRef = useRef<() => void>(null!);
+
+  const shareScreen = useCallback(() => {
+    navigator.mediaDevices
+      .getDisplayMedia({
+        audio: false,
+        video: true,
+      })
+      .then((stream) => {
+        const track = stream.getTracks()[0];
+
+        // All video tracks are published with 'low' priority. This works because the video
+        // track that is displayed in the 'MainParticipant' component will have it's priority
+        // set to 'high' via track.setPriority()
+        room!.localParticipant
+          .publishTrack(track, {
+            name: "screen", // Tracks can be named to easily find them later
+            priority: "low", // Priority is set to high by the subscriber when the video track is rendered
+          } as MediaStreamTrackPublishOptions)
+          .then((trackPublication) => {
+            stopScreenShareRef.current = () => {
+              room!.localParticipant.unpublishTrack(track);
+              // TODO: remove this if the SDK is updated to emit this event
+              room!.localParticipant.emit("trackUnpublished", trackPublication);
+              track.stop();
+              setIsSharing(false);
+            };
+
+            track.onended = stopScreenShareRef.current;
+            setIsSharing(true);
+          })
+          .catch(onError);
+      })
+      .catch((error) => {
+        // Don't display an error if the user closes the screen share dialog
+        if (
+          error.message === "Permission denied by system" ||
+          (error.name !== "AbortError" && error.name !== "NotAllowedError")
+        ) {
+          console.error(error);
+          onError(error);
+        }
+      });
+  }, [room, onError]);
+
+  const toggleScreenShare = useCallback(() => {
+    if (room) {
+      !isSharing ? shareScreen() : stopScreenShareRef.current();
+    }
+  }, [isSharing, shareScreen, room]);
+
+  return [isSharing, toggleScreenShare] as const;
+}


### PR DESCRIPTION
- Remote Participant Screen Sharing UI -- will put the screen share video track in a larger container and shift the participants to the side in a column or row; screen sharing will be disabled for all other participants while someone else is already sharing

Wider screens:
<img width="1735" alt="Screen Shot 2023-01-18 at 8 32 33 AM" src="https://user-images.githubusercontent.com/103593229/213200133-88d6c13d-a5df-4cf7-a394-d6069123fead.png">

Narrower screens:
<img width="1203" alt="Screen Shot 2023-01-18 at 8 33 19 AM" src="https://user-images.githubusercontent.com/103593229/213200200-5cb66c9a-357e-4e88-aae2-95d39fde156c.png">
