### PR TITLE
Remember-devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # vercel
 .vercel
 
+
+# VS Code
+.vscode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": []
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": []
-}

--- a/components/ConfigureSettings/ConfigureSettings.tsx
+++ b/components/ConfigureSettings/ConfigureSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import * as Video from "twilio-video";
 import {
   Button,
@@ -22,10 +22,16 @@ import { useUID } from "@twilio-paste/core/uid-library";
 import { FiSettings } from "react-icons/fi";
 
 import useDevices from "../../lib/hooks/useDevices";
+import useMediaStreamTrack from "../../lib/hooks/useMediaStreamTrack";
 import VideoPreview from "../screens/PreJoinScreen/VideoPreview/VideoPreview";
 import { useVideoStore, VideoAppState } from "../../store/store";
 import { findDeviceByID } from "../../lib/utils/devices";
-import { TEXT_COPY } from "../../lib/constants";
+import {
+  TEXT_COPY,
+  SELECTED_AUDIO_INPUT_KEY,
+  SELECTED_AUDIO_OUTPUT_KEY,
+  SELECTED_VIDEO_INPUT_KEY,
+} from "../../lib/constants";
 
 interface ConfigureSettingsProps {}
 
@@ -39,16 +45,51 @@ export default function ConfigureSettings({}: ConfigureSettingsProps) {
     formData,
     clearTrack,
     devicePermissions,
+    room
   } = useVideoStore((state: VideoAppState) => state);
   const localVideo = localTracks.video;
-  const { identity } = formData;
-
-  const [isOpen, setIsOpen] = React.useState(false);
-  const handleOpen = () => setIsOpen(true);
-  const handleClose = () => setIsOpen(false);
-  const modalHeadingID = useUID();
+  const [storedLocalVideoDeviceId, setStoredLocalVideoDeviceId] = useState(
+    window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY)
+  );
   const { videoInputDevices, audioInputDevices, audioOutputDevices } =
     useDevices(devicePermissions);
+    
+  // Default preview track to local video track if there's one
+  const [previewVideo, setPreviewVideo] = useState(localVideo);
+  // Need the MediaStreamTrack to be able to react to (and re-render) on track restarts 
+  const previewMediaStreamTrack = useMediaStreamTrack(previewVideo);
+  // Get the device ID of the active track, or the preferred device ID from local storage, or the first video input device
+  const videoInputDeviceId = previewMediaStreamTrack?.getSettings().deviceId || storedLocalVideoDeviceId
+      || videoInputDevices?.find((device) => device.kind === "videoinput")?.deviceId;
+
+  
+  const { identity } = formData;
+  const modalHeadingID = useUID();
+
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const handleOpen = () => {
+    if (devicePermissions.camera && videoInputDeviceId) {
+      // Use active track as the preview (if there is one), otherwise create the preview track
+      if (localVideo) {
+        setPreviewVideo(localVideo);
+      } else {
+        // If preview track was stopped on previous close, recreating it is no slower than restarting it (TODO: Fact Check!)
+        createPreviewTrack(videoInputDeviceId);
+      }
+    }
+    setIsOpen(true);
+  }
+
+  const handleClose = () => {
+    // Stop the preview track if it's not the active track (i.e. turn off camera light!)
+    if (!localVideo) { 
+      previewVideo?.stop(); 
+      console.log(`Stopped preview track on close of ConfigureSettings`);
+    }
+    setIsOpen(false);
+  }
+
 
   function deviceChange(
     deviceID: string,
@@ -64,25 +105,40 @@ export default function ConfigureSettings({}: ConfigureSettingsProps) {
     console.log(`changed ${type} to `, device?.label);
 
     /* TODO: NEED TO ADD IN DEVICE CONFIGURATION SWITCHING FOR AUDIO INPUT & OUTPUT */
-    if (type === "video" && localVideo?.mediaStreamTrack.id !== deviceID) {
-      localVideo?.stop();
+    if (type === "video" && previewVideo?.mediaStreamTrack.id !== deviceID) {
+      setStoredLocalVideoDeviceId(deviceID);
+      window.localStorage.setItem(SELECTED_VIDEO_INPUT_KEY, deviceID);
       clearTrack("video");
-      Video.createLocalVideoTrack({
-        deviceId: { exact: deviceID },
-      })
-        .then(function (localVideoTrack) {
-          console.log(
-            `Local Track changed: ${localVideoTrack.kind} (${localVideoTrack})`
-          );
-          setLocalTracks("video", localVideoTrack);
-        })
-        .catch((error) => {
-          toaster.push({
-            message: `Error creating local track - ${error.message}`,
-            variant: "error",
-          });
-        });
+      createPreviewTrack(deviceID);    
     }
+  }
+
+  function createPreviewTrack(deviceID: string) {
+    Video.createLocalVideoTrack({
+      deviceId: { exact: deviceID },
+    }).then((newTrack) => {
+      console.log(`Preview track created with deviceID: ${newTrack.mediaStreamTrack.getSettings().deviceId}`);
+      if (previewVideo) {
+        previewVideo?.stop(); // Stop the old preview track if there is one
+        console.log(`Stopped old preview track before attaching new one`);
+      }
+      setPreviewVideo(newTrack);
+      if (localVideo) {
+        // If in the context of a Room, unpublish the old track
+        const localTrackPublication = room?.localParticipant?.unpublishTrack(localVideo);
+        // TODO: remove when SDK implements this event. See: https://issues.corp.twilio.com/browse/JSDK-2592
+        room?.localParticipant?.emit("trackUnpublished", localTrackPublication);
+        // Set the new track as the active track, and publish
+        setLocalTracks("video", newTrack);
+        room?.localParticipant?.publishTrack(localVideo);
+
+      }
+    }).catch((error) => {
+      toaster.push({
+        message: `Error creating local track - ${error.message}`,
+        variant: "error",
+      });
+    });
   }
 
   useEffect(() => {
@@ -117,7 +173,7 @@ export default function ConfigureSettings({}: ConfigureSettingsProps) {
             {devicePermissions.camera && (
               <VideoPreview
                 identity={identity ?? "Guest"}
-                localVideo={localVideo}
+                localVideo={previewVideo}
               />
             )}
             <Stack orientation="vertical" spacing="space30">
@@ -134,7 +190,7 @@ export default function ConfigureSettings({}: ConfigureSettingsProps) {
                 onChange={(e) => deviceChange(e.target.value, "video")}
                 defaultValue={
                   devicePermissions.camera
-                    ? localVideo?.mediaStreamTrack.id ?? ""
+                    ? videoInputDeviceId ?? ""
                     : "no-cam-permission"
                 }
                 disabled={

--- a/components/screens/ActiveVideoRoom/ActiveVideoRoom.tsx
+++ b/components/screens/ActiveVideoRoom/ActiveVideoRoom.tsx
@@ -76,8 +76,6 @@ export default function ActiveVideoRoom({}) {
       room.on("participantDisconnected", handleParticipantDisconnected);
       room.on("dominantSpeakerChanged", handleDominantSpeakerChanged);
       room.once("disconnected", (room, error) => {
-        console.log("room", room);
-        console.log("error", error);
         localTracks.audio?.stop();
         localTracks.video?.stop();
         localTracks.screen?.stop();

--- a/components/screens/ActiveVideoRoom/LocalControls/ToggleVideo/ToggleVideo.tsx
+++ b/components/screens/ActiveVideoRoom/LocalControls/ToggleVideo/ToggleVideo.tsx
@@ -5,6 +5,7 @@ import { BsCameraVideoFill, BsCameraVideoOff } from "react-icons/bs";
 
 import useDevices from "../../../../../lib/hooks/useDevices";
 import { useVideoStore, VideoAppState } from "../../../../../store/store";
+import { SELECTED_VIDEO_INPUT_KEY } from "../../../../../lib/constants";
 
 export default function ToggleVideo() {
   const toaster = useToaster();
@@ -12,6 +13,7 @@ export default function ToggleVideo() {
   const { localTracks, room, clearTrack, setLocalTracks, devicePermissions } =
     useVideoStore((state: VideoAppState) => state);
   const { hasVideoInputDevices } = useDevices(devicePermissions);
+  const storedLocalVideoDeviceId = window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY);
 
   const toggleVideo = () => {
     if (!isPublishing) {
@@ -29,8 +31,10 @@ export default function ToggleVideo() {
         navigator.mediaDevices
           .enumerateDevices()
           .then((devices) => {
+            // TODO: Tidy this logic. Seems lengthy
             const videoInput = devices.find(
-              (device) => device.kind === "videoinput"
+              (device) => device.kind === "videoinput" && 
+                (!storedLocalVideoDeviceId || device.deviceId === storedLocalVideoDeviceId)  
             );
             return Video.createLocalTracks({
               video: { deviceId: videoInput?.deviceId },

--- a/components/screens/ActiveVideoRoom/LocalControls/ToggleVideo/ToggleVideo.tsx
+++ b/components/screens/ActiveVideoRoom/LocalControls/ToggleVideo/ToggleVideo.tsx
@@ -47,7 +47,6 @@ export default function ToggleVideo() {
             localVideoDeviceId = newDeviceId ?? null;
           });
         }
-        console.log(`DeviceID is ${localVideoDeviceId}`);
 
         if (localVideoDeviceId) {
           Video.createLocalTracks({

--- a/components/screens/PostVideoRoom/SurveyCollection/SurveyCollection.tsx
+++ b/components/screens/PostVideoRoom/SurveyCollection/SurveyCollection.tsx
@@ -51,7 +51,7 @@ export default function SurveyCollection({}) {
       otherIssues,
     };
 
-    console.log("paylod to submit to data warehouse: ", surveyPayload);
+    console.log("payload to submit to data warehouse: ", surveyPayload);
 
     await shipSurveyFeedback(surveyPayload);
 

--- a/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
+++ b/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
@@ -25,6 +25,7 @@ import ConfigureSettings from "../../../ConfigureSettings/ConfigureSettings";
 import { SELECTED_VIDEO_INPUT_KEY, TEXT_COPY } from "../../../../lib/constants";
 import { useGetToken } from "../../../../lib/api";
 import PermissionsWarning from "../PermissionsWarning/PermissionsWarning";
+import useMediaStreamTrack from "../../../../lib/hooks/useMediaStreamTrack";
 
 interface DevicesPresetProps {}
 
@@ -40,6 +41,8 @@ export default function DevicesPreset({}: DevicesPresetProps) {
     setUIStep,
     devicePermissions,
     setDevicePermissions,
+    preferredDevices,
+    setPreferredDevices,
   } = useVideoStore((state: VideoAppState) => state);
 
   const [micEnabled, setMicEnabled] = useState(false);
@@ -50,14 +53,16 @@ export default function DevicesPreset({}: DevicesPresetProps) {
   const { data, status: tokenStatus } = useGetToken(roomName, identity);
   const [loading, setLoading] = useState(false);
 
-  const storedLocalVideoDeviceId = window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY);
+  const localVideo = localTracks.video;
+  // Need the MediaStreamTrack to be able to react to (and re-render) on track restarts
+  const localMediaStreamTrack = useMediaStreamTrack(localVideo);
 
   const joinVideoClicked = async () => {
     setLoading(true);
     let tracks = [];
 
-    if (localTracks.video) {
-      tracks.push(localTracks.video);
+    if (localVideo) {
+      tracks.push(localVideo);
     }
 
     if (localTracks.audio) {
@@ -144,47 +149,67 @@ export default function DevicesPreset({}: DevicesPresetProps) {
     if (camEnabled) {
       // stop the track
       console.log("video track already setup -- stop the track");
-      localTracks.video?.stop();
+      localVideo?.stop();
       clearTrack("video");
       setCamEnabled(false);
     } else {
+      // Refresh preferred device ID from local storage
+      let localVideoDeviceId = localStorage.getItem(SELECTED_VIDEO_INPUT_KEY);
+
       // either request permission and setup the local track
       // if already created but stopped, start the track
-      if (!!localTracks.video) {
+      if (!!localVideo) {
         console.log("video track setup -- start the track");
-        localTracks.video?.restart();
+        localVideo?.restart();
         setCamEnabled(true);
       } else {
         // no existing track, ask for permissions and setup
-        console.log("setup local video track");
-        navigator.mediaDevices
-          .enumerateDevices()
-          .then((devices) => {
-            // TODO: Tidy this logic. Seems lengthy
-            const videoInput = devices.find(
-              (device) => device.kind === "videoinput" && 
-                (!storedLocalVideoDeviceId || device.deviceId === storedLocalVideoDeviceId)  
+        console.log(
+          `setup local video track, local preferred device ID is ${localVideoDeviceId}`
+        );
+        // If we have don't have a device id yet (e.g. from local storage), find one!
+        if (!localVideoDeviceId) {
+          navigator.mediaDevices.enumerateDevices().then((devices) => {
+            const newDeviceId = devices.find(
+              (device) => device.kind === "videoinput"
+            )?.deviceId;
+            console.log(
+              `No existing device ID, so found deviceID ${newDeviceId}`
             );
-            return Video.createLocalTracks({
-              video: { deviceId: videoInput?.deviceId },
-              audio: false,
-            });
-          })
-          .then((localTracks) => {
-            console.log("localTracks...", localTracks);
-            setLocalTracks("video", localTracks[0]);
-            setCamEnabled(true);
-            setDevicePermissions("camera", true);
-          })
-          .catch((error) => {
-            console.log("error", error.message);
-            toaster.push({
-              message: `Error: ${error.message}`,
-              variant: "error",
-            });
-            setCamEnabled(false);
-            setDevicePermissions("camera", false);
+            localVideoDeviceId = newDeviceId ?? null;
           });
+        }
+        console.log(`DeviceID is ${localVideoDeviceId}`);
+
+        if (localVideoDeviceId) {
+          Video.createLocalTracks({
+            video: { deviceId: localVideoDeviceId },
+            audio: false,
+          })
+            .then((localTracks) => {
+              console.log("localTracks...", localTracks);
+              setLocalTracks("video", localTracks[0]);
+              setCamEnabled(true);
+              setDevicePermissions("camera", true);
+            })
+            .catch((error) => {
+              console.log("error", error.message);
+              toaster.push({
+                message: `Error: ${error.message}`,
+                variant: "error",
+              });
+              setCamEnabled(false);
+              setDevicePermissions("camera", false);
+            });
+        } else {
+          console.log("No video input device id found");
+          toaster.push({
+            message: `Error: No video device found`,
+            variant: "error",
+          });
+          setCamEnabled(false);
+          setDevicePermissions("camera", false);
+        }
       }
     }
   }
@@ -227,7 +252,7 @@ export default function DevicesPreset({}: DevicesPresetProps) {
         <Stack orientation="vertical" spacing="space40">
           <VideoPreview
             identity={identity ?? "Guest"}
-            localVideo={localTracks.video}
+            localVideo={localVideo}
           />
           <Flex hAlignContent={"center"}>
             <Switch
@@ -294,7 +319,7 @@ export default function DevicesPreset({}: DevicesPresetProps) {
                   onClick={async () => await joinVideoClicked()}
                   loading={loading}
                   style={{ background: "#F22F46" }}
-                  disabled={preflightStatus !== "passed"}
+                  //disabled={preflightStatus !== "passed"}
                 >
                   {joinButtonText()}
                 </Button>

--- a/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
+++ b/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
@@ -41,8 +41,6 @@ export default function DevicesPreset({}: DevicesPresetProps) {
     setUIStep,
     devicePermissions,
     setDevicePermissions,
-    preferredDevices,
-    setPreferredDevices,
   } = useVideoStore((state: VideoAppState) => state);
 
   const [micEnabled, setMicEnabled] = useState(false);

--- a/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
+++ b/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
@@ -22,7 +22,7 @@ import { UIStep, useVideoStore, VideoAppState } from "../../../../store/store";
 import { MaxWidthDiv } from "../../../styled";
 import VideoPreview from "../VideoPreview/VideoPreview";
 import ConfigureSettings from "../../../ConfigureSettings/ConfigureSettings";
-import { TEXT_COPY } from "../../../../lib/constants";
+import { SELECTED_VIDEO_INPUT_KEY, TEXT_COPY } from "../../../../lib/constants";
 import { useGetToken } from "../../../../lib/api";
 import PermissionsWarning from "../PermissionsWarning/PermissionsWarning";
 
@@ -49,6 +49,8 @@ export default function DevicesPreset({}: DevicesPresetProps) {
   const { roomName, identity } = formData;
   const { data, status: tokenStatus } = useGetToken(roomName, identity);
   const [loading, setLoading] = useState(false);
+
+  const storedLocalVideoDeviceId = window.localStorage.getItem(SELECTED_VIDEO_INPUT_KEY);
 
   const joinVideoClicked = async () => {
     setLoading(true);
@@ -158,8 +160,10 @@ export default function DevicesPreset({}: DevicesPresetProps) {
         navigator.mediaDevices
           .enumerateDevices()
           .then((devices) => {
+            // TODO: Tidy this logic. Seems lengthy
             const videoInput = devices.find(
-              (device) => device.kind === "videoinput"
+              (device) => device.kind === "videoinput" && 
+                (!storedLocalVideoDeviceId || device.deviceId === storedLocalVideoDeviceId)  
             );
             return Video.createLocalTracks({
               video: { deviceId: videoInput?.deviceId },

--- a/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
+++ b/components/screens/PreJoinScreen/DevicesPreset/DevicesPreset.tsx
@@ -125,7 +125,6 @@ export default function DevicesPreset({}: DevicesPresetProps) {
             });
           })
           .then((localTracks) => {
-            console.log("localTracks...", localTracks);
             setLocalTracks("audio", localTracks[0]);
             setMicEnabled(true);
             setDevicePermissions("microphone", true);
@@ -177,7 +176,6 @@ export default function DevicesPreset({}: DevicesPresetProps) {
             localVideoDeviceId = newDeviceId ?? null;
           });
         }
-        console.log(`DeviceID is ${localVideoDeviceId}`);
 
         if (localVideoDeviceId) {
           Video.createLocalTracks({
@@ -185,7 +183,6 @@ export default function DevicesPreset({}: DevicesPresetProps) {
             audio: false,
           })
             .then((localTracks) => {
-              console.log("localTracks...", localTracks);
               setLocalTracks("video", localTracks[0]);
               setCamEnabled(true);
               setDevicePermissions("camera", true);
@@ -317,7 +314,7 @@ export default function DevicesPreset({}: DevicesPresetProps) {
                   onClick={async () => await joinVideoClicked()}
                   loading={loading}
                   style={{ background: "#F22F46" }}
-                  //disabled={preflightStatus !== "passed"}
+                  disabled={preflightStatus !== "passed"}
                 >
                   {joinButtonText()}
                 </Button>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,4 @@
+// TODO: Use DEFAULT_VIDEO_CONSTRAINTS
 export const DEFAULT_VIDEO_CONSTRAINTS: MediaStreamConstraints["video"] = {
   width: 1280,
   height: 720,
@@ -8,10 +9,6 @@ export const DEFAULT_VIDEO_CONSTRAINTS: MediaStreamConstraints["video"] = {
 export const SELECTED_AUDIO_INPUT_KEY = "TwilioVideoApp-selectedAudioInput";
 export const SELECTED_AUDIO_OUTPUT_KEY = "TwilioVideoApp-selectedAudioOutput";
 export const SELECTED_VIDEO_INPUT_KEY = "TwilioVideoApp-selectedVideoInput";
-
-// This is used to store the current background settings in localStorage
-export const SELECTED_BACKGROUND_SETTINGS_KEY =
-  "TwilioVideoApp-selectedBackgroundSettings";
 
 export const GALLERY_VIEW_ASPECT_RATIO = 9 / 16; // 16:9
 export const GALLERY_VIEW_MARGIN = 4;

--- a/lib/hooks/usePublications.ts
+++ b/lib/hooks/usePublications.ts
@@ -16,12 +16,17 @@ export default function usePublications(participant: Participant) {
       Array.from(participant.tracks.values()) as TrackPublication[]
     );
 
-    const publicationAdded = (publication: TrackPublication) =>
+    const publicationAdded = (publication: TrackPublication) => {
+      console.log("publication added", publication);
       setPublications((prevPublications) => [...prevPublications, publication]);
-    const publicationRemoved = (publication: TrackPublication) =>
+    }
+
+    const publicationRemoved = (publication: TrackPublication) => {
+      console.log("publication removed", publication);
       setPublications((prevPublications) =>
         prevPublications.filter((p) => p !== publication)
       );
+    }
 
     participant.on("trackPublished", publicationAdded);
     participant.on("trackUnpublished", publicationRemoved);


### PR DESCRIPTION
First pass at remembering preferred device in localStorage (video input only for now), and defaulting to that when toggling video on or when accessing the ConfigureSettings modal.

Also handles the separate preview video track in ConfigureSettings - to allow user to preview the selected input device's track before actually toggling it on from either DevicesPreset or ToggleVideo.